### PR TITLE
Add booking selection interface and iCal proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,20 @@ This template uses **Formspree** for form submissions.
 
 > Tip: In Formspree, set a confirmation email and webhook if you want to pipe leads to a Google Sheet/CRM later.
 
+## Booking requests via iCal
+The page also lets hosts load an iCal feed of bookings, tick which stays need hampers and submit the selection to an API.
+
+1. **Deploy the worker**
+   - Create a Cloudflare Worker and paste in `server/worker.js`.
+   - Publish and note the Worker URL (e.g. `https://example.workers.dev`).
+2. **Configure the front end**
+   - In `script.js`, set:
+     ```js
+     const WORKER_BASE = 'https://example.workers.dev';
+     const SUBMIT_ENDPOINT = 'https://your-api.example.com/hamper-requests';
+     ```
+3. Paste an Airbnb/VRBO iCal URL on the page and load bookings. Select one or more events and submit to send a JSON payload to your endpoint.
+
 ## Local development
 Just open `index.html` in your browser. For a simple local server:
 ```bash

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
       <a href="#how-it-works">How it works</a>
       <a href="#whats-inside">What’s inside</a>
       <a href="#request">Get a sample</a>
+      <a href="#bookings">Bookings</a>
     </nav>
   </header>
 
@@ -150,6 +151,21 @@
         <summary>Privacy Notice (AU)</summary>
         <p>We collect the information on this form to arrange a sample delivery and to contact you with product updates. You can opt out at any time. We do not sell your data. Data is stored securely and accessed only by our team. For questions, email hello@example.com.</p>
       </details>
+    </section>
+
+    <section id="bookings" class="section container">
+      <h2>Booking Requests</h2>
+      <label for="ical-url">iCal URL</label>
+      <div class="row">
+        <input id="ical-url" type="url" placeholder="https://example.com/calendar.ics" required>
+        <button id="load-btn" type="button">Load bookings</button>
+      </div>
+      <p id="load-status" class="status" aria-live="polite"></p>
+      <form id="booking-form" class="hidden">
+        <ul id="events-list"></ul>
+        <button type="submit" id="submit-btn" class="btn btn-primary">Submit selected</button>
+        <p id="submit-status" class="status" aria-live="polite"></p>
+      </form>
     </section>
   </main>
 

--- a/script.js
+++ b/script.js
@@ -1,11 +1,11 @@
 // Basic enhancements & form submission to Formspree
 document.getElementById('year').textContent = new Date().getFullYear();
 
-const form = document.getElementById('lead-form');
+const leadForm = document.getElementById('lead-form');
 const statusEl = document.getElementById('form-status');
 const endpoint = document.getElementById('form-endpoint').value;
 
-form.addEventListener('submit', async (e) => {
+leadForm.addEventListener('submit', async (e) => {
   e.preventDefault();
   statusEl.className = 'status';
   statusEl.textContent = 'Sending…';
@@ -18,7 +18,7 @@ form.addEventListener('submit', async (e) => {
     return;
   }
 
-  const data = new FormData(form);
+    const data = new FormData(leadForm);
 
   try{
     const res = await fetch(endpoint, {
@@ -28,7 +28,7 @@ form.addEventListener('submit', async (e) => {
     });
 
     if (res.ok) {
-      form.reset();
+      leadForm.reset();
       statusEl.classList.add('ok');
       statusEl.textContent = 'Thanks! We\'ll be in touch to schedule your sample.';
     } else {
@@ -41,3 +41,133 @@ form.addEventListener('submit', async (e) => {
     statusEl.textContent = 'Network error. Please check your connection and try again.';
   }
 });
+
+// Booking request logic
+const WORKER_BASE = 'https://<your-worker>.workers.dev';
+const SUBMIT_ENDPOINT = 'https://example.com/api/hamper-requests';
+
+const loadBtn = document.getElementById('load-btn');
+const icalInput = document.getElementById('ical-url');
+const loadStatus = document.getElementById('load-status');
+const bookingForm = document.getElementById('booking-form');
+const list = document.getElementById('events-list');
+const submitStatus = document.getElementById('submit-status');
+
+let loadedEvents = [];
+
+loadBtn.addEventListener('click', async () => {
+  const url = icalInput.value.trim();
+  if (!url) {
+    loadStatus.textContent = 'Please enter an iCal URL.';
+    loadStatus.className = 'status err';
+    return;
+  }
+  loadStatus.textContent = 'Loading…';
+  loadStatus.className = 'status';
+
+  try {
+    const resp = await fetch(`${WORKER_BASE}/ical?url=${encodeURIComponent(url)}`);
+    if (!resp.ok) throw new Error();
+    const data = await resp.json();
+    const now = new Date();
+    loadedEvents = (data.events || [])
+      .map(ev => ({ ...ev, start: new Date(ev.start), end: new Date(ev.end) }))
+      .filter(ev => ev.end >= now)
+      .sort((a, b) => a.start - b.start);
+
+    list.innerHTML = '';
+    if (loadedEvents.length === 0) {
+      loadStatus.textContent = 'No upcoming bookings found.';
+      bookingForm.classList.add('hidden');
+      return;
+    }
+
+    loadedEvents.forEach((ev, i) => {
+      const li = document.createElement('li');
+      li.className = 'event';
+      li.dataset.index = i;
+
+      const top = document.createElement('div');
+      top.className = 'top';
+      const check = document.createElement('input');
+      check.type = 'checkbox';
+      check.className = 'check';
+      const summary = document.createElement('span');
+      summary.className = 'summary';
+      summary.textContent = ev.summary || 'Booking';
+      const dates = document.createElement('span');
+      dates.className = 'dates';
+      dates.textContent = formatDateRange(ev.start, ev.end);
+      top.append(check, summary, dates);
+
+      const note = document.createElement('input');
+      note.type = 'text';
+      note.className = 'note';
+      note.placeholder = 'Note (optional)';
+
+      li.append(top, note);
+      list.appendChild(li);
+    });
+
+    bookingForm.classList.remove('hidden');
+    loadStatus.textContent = '';
+  } catch (err) {
+    bookingForm.classList.add('hidden');
+    loadStatus.textContent = 'Could not load calendar.';
+    loadStatus.className = 'status err';
+  }
+});
+
+bookingForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  submitStatus.textContent = '';
+  submitStatus.className = 'status';
+
+  const selections = [];
+  list.querySelectorAll('li').forEach(li => {
+    const check = li.querySelector('.check');
+    if (check.checked) {
+      const idx = Number(li.dataset.index);
+      const ev = loadedEvents[idx];
+      const note = li.querySelector('.note').value.trim();
+      selections.push({
+        start: ev.start.toISOString(),
+        end: ev.end.toISOString(),
+        summary: ev.summary,
+        note
+      });
+    }
+  });
+
+  if (selections.length === 0) {
+    submitStatus.textContent = 'Please select at least one booking.';
+    submitStatus.className = 'status err';
+    return;
+  }
+
+  submitStatus.textContent = 'Submitting…';
+  try {
+    const res = await fetch(SUBMIT_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ical_source: icalInput.value.trim(),
+        selected_bookings: selections
+      })
+    });
+    if (!res.ok) throw new Error();
+    submitStatus.textContent = 'Submitted!';
+    submitStatus.className = 'status ok';
+  } catch (err) {
+    submitStatus.textContent = 'Submission failed.';
+    submitStatus.className = 'status err';
+  }
+});
+
+function formatDateRange(start, end) {
+  const opts = { day: 'numeric', month: 'short' };
+  const startStr = start.toLocaleDateString(undefined, opts);
+  const endOpts = { day: 'numeric', month: 'short', year: 'numeric' };
+  const endStr = end.toLocaleDateString(undefined, endOpts);
+  return `${startStr} – ${endStr}`;
+}

--- a/server/worker.js
+++ b/server/worker.js
@@ -1,0 +1,86 @@
+export default {
+  async fetch(request) {
+    if (request.method === 'OPTIONS') {
+      return new Response(null, {
+        headers: corsHeaders()
+      });
+    }
+
+    const url = new URL(request.url);
+    if (url.pathname === '/ical') {
+      const icsUrl = url.searchParams.get('url');
+      const headers = corsHeaders();
+      if (!icsUrl) {
+        return new Response(JSON.stringify({ error: 'Missing url' }), { status: 400, headers });
+      }
+      let remote;
+      try {
+        remote = new URL(icsUrl);
+      } catch {
+        return new Response(JSON.stringify({ error: 'Invalid url' }), { status: 400, headers });
+      }
+      const allowed = ['airbnb.com', 'airbnb.com.au', 'vrbo.com'];
+      if (!allowed.some(h => remote.hostname === h || remote.hostname.endsWith('.' + h))) {
+        return new Response(JSON.stringify({ error: 'Host not allowed' }), { status: 400, headers });
+      }
+      try {
+        const resp = await fetch(icsUrl);
+        if (!resp.ok) {
+          return new Response(JSON.stringify({ error: 'Upstream error' }), { status: 502, headers });
+        }
+        const text = await resp.text();
+        const events = parseICS(text);
+        return new Response(JSON.stringify({ events }), { headers });
+      } catch {
+        return new Response(JSON.stringify({ error: 'Fetch failed' }), { status: 500, headers });
+      }
+    }
+    return new Response('Not found', { status: 404, headers: corsHeaders() });
+  }
+};
+
+function corsHeaders() {
+  return {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*'
+  };
+}
+
+function parseICS(text) {
+  const events = [];
+  const blocks = text.split('BEGIN:VEVENT').slice(1);
+  for (const block of blocks) {
+    const body = block.split('END:VEVENT')[0];
+    const lines = body.split(/\r?\n/);
+    let start, end, summary;
+    for (const line of lines) {
+      if (line.startsWith('DTSTART')) {
+        const [, v] = line.split(':');
+        start = parseICalDate(v.trim());
+      } else if (line.startsWith('DTEND')) {
+        const [, v] = line.split(':');
+        end = parseICalDate(v.trim());
+      } else if (line.startsWith('SUMMARY')) {
+        const [, v] = line.split(':');
+        summary = v.trim();
+      }
+    }
+    if (start && end) {
+      events.push({ start, end, summary });
+    }
+  }
+  return events;
+}
+
+function parseICalDate(str) {
+  if (/^\d{8}$/.test(str)) {
+    return `${str.slice(0,4)}-${str.slice(4,6)}-${str.slice(6,8)}T00:00:00`;
+  }
+  if (/^\d{8}T\d{6}Z$/.test(str)) {
+    return `${str.slice(0,4)}-${str.slice(4,6)}-${str.slice(6,8)}T${str.slice(9,11)}:${str.slice(11,13)}:${str.slice(13,15)}Z`;
+  }
+  if (/^\d{8}T\d{6}$/.test(str)) {
+    return `${str.slice(0,4)}-${str.slice(4,6)}-${str.slice(6,8)}T${str.slice(9,11)}:${str.slice(11,13)}:${str.slice(13,15)}`;
+  }
+  return str;
+}

--- a/styles.css
+++ b/styles.css
@@ -56,3 +56,20 @@ input,select,textarea{padding:12px;border:1px solid var(--line);border-radius:10
   .grid-2{grid-template-columns:1fr}
   .form-grid{grid-template-columns:1fr}
 }
+
+#bookings .row{display:flex;gap:8px}
+#bookings input[type="url"]{flex:1;padding:8px;border:1px solid var(--line);border-radius:4px}
+#bookings button{padding:8px 12px;border:none;background:var(--brand);color:#fff;border-radius:4px;cursor:pointer}
+#bookings button:disabled{opacity:.6;cursor:not-allowed}
+#bookings ul{list-style:none;padding:0;margin:16px 0}
+#bookings .event{border-bottom:1px solid var(--line);padding:8px 0}
+#bookings .event .top{display:flex;align-items:center;gap:8px}
+#bookings .event .summary{font-weight:600}
+#bookings .event .dates{font-size:.9rem;margin-left:4px;color:var(--text)}
+#bookings .event .note{margin-left:24px;margin-top:4px;width:100%;padding:6px;border:1px solid var(--line);border-radius:4px}
+.hidden{display:none}
+@media(max-width:480px){
+  #bookings .row{flex-direction:column}
+  #bookings button{width:100%}
+  #bookings .event .note{margin-left:0}
+}


### PR DESCRIPTION
## Summary
- Restore original landing page and sample request form
- Add bookings section that loads iCal feeds and submits selected stays
- Document Cloudflare worker and endpoint configuration

## Testing
- `node --check script.js && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_68c3a5a8703c832e865f0c7b94109b9b