### PR TITLE
feat: add site sections and iCal upload form

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,9 +7,25 @@
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+  <header class="hero">
+    <h1>Harbour Hampers</h1>
+    <p>Delicious welcome hampers for your guests</p>
+  </header>
   <main class="container">
-    <h1>Harbour Hampers Booking Requests</h1>
+    <section class="intro">
+      <h2>Welcome</h2>
+      <p>Use this tool to request hampers for your upcoming bookings.</p>
+    </section>
+    <section class="process">
+      <h2>How it works</h2>
+      <ol>
+        <li>Paste your property's iCal URL below.</li>
+        <li>Select the bookings that need hampers.</li>
+        <li>Submit and we'll take care of the rest.</li>
+      </ol>
+    </section>
     <section id="loader">
+      <h2>Load bookings</h2>
       <label for="ical-url">iCal URL</label>
       <div class="row">
         <input id="ical-url" type="url" placeholder="https://example.com/calendar.ics" required>

--- a/styles.css
+++ b/styles.css
@@ -8,12 +8,17 @@
 body{
   font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
   margin:0;
-  padding:20px;
+  padding:0;
   color:var(--text);
   background:#fff;
 }
-.container{max-width:600px;margin:0 auto;}
+.container{max-width:600px;margin:0 auto;padding:20px;}
 h1{font-size:1.5rem;}
+.hero{background:var(--brand);color:#fff;text-align:center;padding:60px 20px;}
+.hero h1{margin:0;font-size:2rem;}
+.hero p{margin-top:8px;font-size:1.1rem;}
+.intro,.process{margin:40px 0;}
+.process ol{padding-left:20px;}
 .row{display:flex;gap:8px;}
 #ical-url{flex:1;padding:8px;border:1px solid var(--line);border-radius:4px;}
 button{padding:8px 12px;border:none;background:var(--brand);color:#fff;border-radius:4px;cursor:pointer;}


### PR DESCRIPTION
## Summary
- add hero, intro and process sections to homepage
- keep iCal upload form for booking requests
- style new sections and hero layout

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c737a32d7c832e8f8e1bb1a427648e