### PR TITLE
Add HAMPA marketing landing page and iCal worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,50 @@
-# Harbour Hampers – Booking Request Demo
+# HAMPA marketing page
 
-This demo lets a host load an iCal feed of bookings, choose which stays need hampers and submit the selection to an API.
+Static one-pager for HAMPA welcome hampers.
 
 ## Files
 
-- `index.html`, `styles.css`, `script.js` – front end.
-- `server/worker.js` – Cloudflare Worker proxy that fetches and parses `.ics` files.
+- `index.html` – landing page and forms.
+- `styles.css` – minimal theme.
+- `script.js` – Formspree submits and iCal loader.
+- `assets/` – logo; add your own `og.png` for social sharing.
+- `server/worker.js` – Cloudflare Worker proxy for iCal → JSON.
 
 ## Setup
 
 1. **Deploy the worker**
-   - Create a new Cloudflare Worker and paste in `server/worker.js`.
-   - Publish and note the Worker URL (e.g. `https://example.workers.dev`).
-2. **Configure the front end**
-   - In `script.js`, set:
-     ```js
-     const WORKER_BASE = 'https://example.workers.dev';
-     const SUBMIT_ENDPOINT = 'https://your-api.example.com/hamper-requests';
-     ```
-3. Serve `index.html` from any static host or open it directly in your browser.
+   - In Cloudflare dashboard create a Worker and paste `server/worker.js`.
+   - Publish and note the public URL (e.g. `https://example.workers.dev`).
+2. **Formspree endpoints**
+   - Create two forms in [Formspree](https://formspree.io).
+   - Replace the values of the hidden inputs `#form-endpoint` and `#hamper-endpoint` in `index.html` with the form URLs.
+3. **Configure `script.js`**
+   - Set `WORKER_BASE` to your Worker URL.
+4. **GitHub Pages**
+   - Push this repo to GitHub.
+   - In repository settings → Pages, choose the main branch root as the source.
+   - The site will be served from `https://<user>.github.io/<repo>/`.
 
 ## Usage
 
-1. Paste an Airbnb/VRBO iCal URL and click **Load bookings**.
-2. Upcoming events are listed with a checkbox and optional note field.
-3. Select one or more bookings and click **Submit selected**.
-4. The page sends a `POST` request to `SUBMIT_ENDPOINT` with JSON:
-   ```json
-   {
-     "ical_source": "<original url>",
-     "selected_bookings": [
-       {
-         "start": "2025-09-13T14:00:00Z",
-         "end": "2025-09-15T10:00:00Z",
-         "summary": "Reserved",
-         "note": "Please deliver after 1pm"
-       }
-     ]
-   }
-   ```
+1. Open the page via GitHub Pages or a local file server.
+2. Fill out the sample request form. Required fields and consent must be checked.
+3. For bookings, paste an Airbnb/VRBO/Booking.com iCal URL and click **Load bookings**.
+4. Select upcoming events, add notes and delivery preferences, confirm consent and submit.
+5. Both forms send `POST` requests to their Formspree endpoints and show inline success/error messages.
 
-## Testing
+## Worker endpoint
 
-- Use a real Airbnb iCal export for manual testing.
-- Point `SUBMIT_ENDPOINT` to a request catcher (e.g., https://webhook.site) to verify the payload.
-- The Worker parser handles all-day events and timed events with/without `Z`.
+`GET /ical?url=<encoded_ics_url>` → `{ "events": [{"start":"...","end":"...","summary":"..."}] }`
 
-## Local development
+Only calendars from `airbnb.com`, `airbnb.com.au`, `abnb.me`, `vrbo.com` and `booking.com` are proxied. CORS header `Access-Control-Allow-Origin: *` allows browser use.
 
-No build step is required. Start a simple static file server (e.g., `python -m http.server 8000`) or open `index.html` directly.
+## Development
+
+No build step is required. Serve the repo with any static server, e.g.:
+
+```bash
+python -m http.server 8000
+```
+
+Then open `http://localhost:8000`.

--- a/index.html
+++ b/index.html
@@ -3,42 +3,107 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Harbour Hampers – Booking Requests</title>
+  <title>HAMPA – First Impressions, Handled.</title>
+  <meta name="description" content="Pre-arrival welcome hampers for Sydney short-stay hosts."/>
+  <meta property="og:image" content="assets/og.png"/>
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <header class="hero">
-    <h1>Harbour Hampers</h1>
-    <p>Delicious welcome hampers for your guests</p>
-  </header>
-  <main class="container">
-    <section class="intro">
-      <h2>Welcome</h2>
-      <p>Use this tool to request hampers for your upcoming bookings.</p>
-    </section>
-    <section class="process">
-      <h2>How it works</h2>
-      <ol>
-        <li>Paste your property's iCal URL below.</li>
-        <li>Select the bookings that need hampers.</li>
-        <li>Submit and we'll take care of the rest.</li>
-      </ol>
-    </section>
-    <section id="loader">
-      <h2>Load bookings</h2>
-      <label for="ical-url">iCal URL</label>
-      <div class="row">
-        <input id="ical-url" type="url" placeholder="https://example.com/calendar.ics" required>
-        <button id="load-btn">Load bookings</button>
-      </div>
-      <p id="load-status" class="status" aria-live="polite"></p>
-    </section>
-    <form id="booking-form" class="hidden">
-      <ul id="events-list"></ul>
-      <button type="submit" id="submit-btn">Submit selected</button>
-      <p id="submit-status" class="status" aria-live="polite"></p>
+<header class="brand">
+  <img src="assets/logo.svg" alt="HAMPA" class="logo">
+</header>
+
+<section class="hero">
+  <h1>HAMPA</h1>
+  <p class="tagline">First Impressions, Handled.</p>
+  <p class="pitch">Pre-arrival welcome hampers for Sydney short-stay hosts — local favourites, guest essentials and a mini guide, delivered before check-in.</p>
+  <div class="actions">
+    <a href="#sample" class="btn">Request a sample</a>
+    <a href="#calendar" class="btn ghost">Connect calendar</a>
+  </div>
+</section>
+
+<main class="container">
+  <section class="how">
+    <h2>How it works</h2>
+    <ol class="cards">
+      <li>Choose your hamper <span class="note">(standard; options later)</span>.</li>
+      <li>Tell us your schedule <span class="note">(form or via calendar)</span>.</li>
+      <li>We handle the rest <span class="note">(assemble, deliver, restock)</span>.</li>
+    </ol>
+  </section>
+
+  <section class="inside">
+    <h2>What’s inside</h2>
+    <ul>
+      <li>Tim Tams</li>
+      <li>Byron Bay Cookies</li>
+      <li>T2 + local coffee</li>
+      <li>mini honey/jam</li>
+      <li>2× sparkling waters</li>
+      <li>tote + welcome card</li>
+      <li>optional eco toiletries</li>
+    </ul>
+    <p class="note">Local guide card included. Suburb add-ons: Bondi, Surry Hills, Manly.</p>
+  </section>
+
+  <section id="sample" class="lead">
+    <h2>Request a complimentary sample</h2>
+    <form id="lead-form">
+      <input type="hidden" id="form-endpoint" value="https://formspree.io/f/YOUR_FORMSPREE_ID">
+      <label for="name">Name*</label>
+      <input id="name" name="name" required>
+      <label for="company">Company</label>
+      <input id="company" name="company">
+      <label for="email">Email*</label>
+      <input id="email" name="email" type="email" required>
+      <label for="phone">Phone</label>
+      <input id="phone" name="phone" type="tel">
+      <label for="listings"># listings</label>
+      <input id="listings" name="listings" type="number" min="0">
+      <label for="suburbs">Delivery suburbs</label>
+      <input id="suburbs" name="suburbs">
+      <label class="checkbox"><input type="checkbox" id="consent" required> I agree to be contacted about HAMPA.</label>
+      <button type="submit" class="btn">Send request</button>
+      <p id="lead-status" class="status" aria-live="polite"></p>
     </form>
-  </main>
-  <script src="script.js"></script>
+    <details class="privacy">
+      <summary>Privacy notice</summary>
+      <p>We use your details solely to respond to your enquiry. Contact <a href="mailto:privacy@hampa.example">privacy@hampa.example</a> for access or removal.</p>
+    </details>
+  </section>
+
+  <section id="calendar" class="calendar">
+    <h2>Hosts — choose which bookings get a hamper</h2>
+    <label for="ical-url">iCal URL</label>
+    <div class="row">
+      <input id="ical-url" type="url" placeholder="https://example.com/calendar.ics">
+      <button id="load-btn" class="btn">Load bookings</button>
+    </div>
+    <p id="load-status" class="status" aria-live="polite"></p>
+
+    <form id="hamper-form" class="hidden">
+      <input type="hidden" id="hamper-endpoint" value="https://formspree.io/f/YOUR_FORMSPREE_ID2">
+      <ul id="events-list"></ul>
+      <label for="delivery-prefs">Delivery preferences</label>
+      <textarea id="delivery-prefs" rows="3"></textarea>
+      <label class="checkbox"><input type="checkbox" id="consent2" required> I confirm I am the host/manager and consent to sending booking dates to HAMPA.</label>
+      <button type="submit" class="btn">Submit</button>
+      <p id="hamper-status" class="status" aria-live="polite"></p>
+      <p class="footnote">iCal doesn’t include guest names; dates only.</p>
+    </form>
+
+    <details class="troubleshoot">
+      <summary>Troubleshooting</summary>
+      <p>If you see a CORS error, make sure you paste the Airbnb export URL above and that the request goes through the Worker proxy.</p>
+    </details>
+  </section>
+</main>
+
+<footer class="footer">
+  <p>© <span id="year"></span> HAMPA · Sydney, Australia. Disclaimer: not affiliated with Airbnb.</p>
+</footer>
+
+<script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,14 +1,46 @@
 const WORKER_BASE = 'https://<your-worker>.workers.dev';
-const SUBMIT_ENDPOINT = 'https://example.com/api/hamper-requests';
 
+// set footer year
+const yearEl = document.getElementById('year');
+if (yearEl) yearEl.textContent = new Date().getFullYear();
+
+// lead form
+const leadForm = document.getElementById('lead-form');
+const leadStatus = document.getElementById('lead-status');
+const leadEndpoint = document.getElementById('form-endpoint').value;
+if (leadForm) {
+  leadForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    leadStatus.textContent = 'Sending…';
+    leadStatus.className = 'status';
+    try {
+      const res = await fetch(leadEndpoint, {
+        method: 'POST',
+        body: new FormData(leadForm),
+        headers: { 'Accept': 'application/json' }
+      });
+      if (!res.ok) throw new Error();
+      leadForm.reset();
+      leadStatus.textContent = 'Thanks! Check your inbox.';
+      leadStatus.className = 'status ok';
+    } catch {
+      leadStatus.textContent = 'Something went wrong.';
+      leadStatus.className = 'status err';
+    }
+  });
+}
+
+// calendar loading and submission
 const loadBtn = document.getElementById('load-btn');
 const icalInput = document.getElementById('ical-url');
 const loadStatus = document.getElementById('load-status');
-const form = document.getElementById('booking-form');
-const list = document.getElementById('events-list');
-const submitStatus = document.getElementById('submit-status');
-
-let loadedEvents = [];
+const hamperForm = document.getElementById('hamper-form');
+const eventsList = document.getElementById('events-list');
+const hamperStatus = document.getElementById('hamper-status');
+const hamperEndpoint = document.getElementById('hamper-endpoint').value;
+const deliveryPrefs = document.getElementById('delivery-prefs');
+const consent2 = document.getElementById('consent2');
+let events = [];
 
 loadBtn.addEventListener('click', async () => {
   const url = icalInput.value.trim();
@@ -19,73 +51,69 @@ loadBtn.addEventListener('click', async () => {
   }
   loadStatus.textContent = 'Loading…';
   loadStatus.className = 'status';
-
   try {
     const resp = await fetch(`${WORKER_BASE}/ical?url=${encodeURIComponent(url)}`);
     if (!resp.ok) throw new Error();
     const data = await resp.json();
     const now = new Date();
-    loadedEvents = (data.events || [])
+    events = (data.events || [])
       .map(ev => ({ ...ev, start: new Date(ev.start), end: new Date(ev.end) }))
       .filter(ev => ev.end >= now)
-      .sort((a, b) => a.start - b.start);
+      .sort((a,b) => a.start - b.start);
 
-    list.innerHTML = '';
-    if (loadedEvents.length === 0) {
+    eventsList.innerHTML = '';
+    if (events.length === 0) {
+      hamperForm.classList.add('hidden');
       loadStatus.textContent = 'No upcoming bookings found.';
-      form.classList.add('hidden');
       return;
     }
-
-    loadedEvents.forEach((ev, i) => {
+    events.forEach((ev, idx) => {
       const li = document.createElement('li');
-      li.className = 'event';
-      li.dataset.index = i;
-
-      const top = document.createElement('div');
-      top.className = 'top';
+      const label = document.createElement('label');
       const check = document.createElement('input');
       check.type = 'checkbox';
       check.className = 'check';
+      check.dataset.index = idx;
       const summary = document.createElement('span');
       summary.className = 'summary';
       summary.textContent = ev.summary || 'Booking';
       const dates = document.createElement('span');
       dates.className = 'dates';
-      dates.textContent = formatDateRange(ev.start, ev.end);
-      top.append(check, summary, dates);
-
+      dates.textContent = formatRange(ev.start, ev.end);
+      label.append(check, summary, dates);
       const note = document.createElement('input');
       note.type = 'text';
-      note.className = 'note';
       note.placeholder = 'Note (optional)';
-
-      li.append(top, note);
-      list.appendChild(li);
+      note.className = 'note';
+      li.append(label, note);
+      eventsList.appendChild(li);
     });
-
-    form.classList.remove('hidden');
+    hamperForm.classList.remove('hidden');
     loadStatus.textContent = '';
   } catch (err) {
-    form.classList.add('hidden');
+    hamperForm.classList.add('hidden');
     loadStatus.textContent = 'Could not load calendar.';
     loadStatus.className = 'status err';
   }
 });
 
-form.addEventListener('submit', async (e) => {
+hamperForm.addEventListener('submit', async (e) => {
   e.preventDefault();
-  submitStatus.textContent = '';
-  submitStatus.className = 'status';
-
-  const selections = [];
-  list.querySelectorAll('li').forEach(li => {
+  hamperStatus.textContent = '';
+  hamperStatus.className = 'status';
+  if (!consent2.checked) {
+    hamperStatus.textContent = 'Consent required.';
+    hamperStatus.className = 'status err';
+    return;
+  }
+  const selected = [];
+  eventsList.querySelectorAll('li').forEach(li => {
     const check = li.querySelector('.check');
     if (check.checked) {
-      const idx = Number(li.dataset.index);
-      const ev = loadedEvents[idx];
+      const idx = Number(check.dataset.index);
+      const ev = events[idx];
       const note = li.querySelector('.note').value.trim();
-      selections.push({
+      selected.push({
         start: ev.start.toISOString(),
         end: ev.end.toISOString(),
         summary: ev.summary,
@@ -93,36 +121,29 @@ form.addEventListener('submit', async (e) => {
       });
     }
   });
-
-  if (selections.length === 0) {
-    submitStatus.textContent = 'Please select at least one booking.';
-    submitStatus.className = 'status err';
+  if (selected.length === 0) {
+    hamperStatus.textContent = 'Select at least one booking.';
+    hamperStatus.className = 'status err';
     return;
   }
-
-  submitStatus.textContent = 'Submitting…';
+  hamperStatus.textContent = 'Submitting…';
   try {
-    const res = await fetch(SUBMIT_ENDPOINT, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        ical_source: icalInput.value.trim(),
-        selected_bookings: selections
-      })
-    });
+    const fd = new FormData();
+    fd.append('selected_bookings_json', JSON.stringify(selected));
+    fd.append('delivery_prefs', deliveryPrefs.value.trim());
+    const res = await fetch(hamperEndpoint, { method: 'POST', body: fd, headers:{'Accept':'application/json'} });
     if (!res.ok) throw new Error();
-    submitStatus.textContent = 'Submitted!';
-    submitStatus.className = 'status ok';
-  } catch (err) {
-    submitStatus.textContent = 'Submission failed.';
-    submitStatus.className = 'status err';
+    hamperForm.reset();
+    hamperStatus.textContent = 'Submitted!';
+    hamperStatus.className = 'status ok';
+  } catch {
+    hamperStatus.textContent = 'Submission failed.';
+    hamperStatus.className = 'status err';
   }
 });
 
-function formatDateRange(start, end) {
-  const opts = { day: 'numeric', month: 'short' };
-  const startStr = start.toLocaleDateString(undefined, opts);
-  const endOpts = { day: 'numeric', month: 'short', year: 'numeric' };
-  const endStr = end.toLocaleDateString(undefined, endOpts);
-  return `${startStr} – ${endStr}`;
+function formatRange(start, end) {
+  const startStr = start.toLocaleString(undefined, { weekday:'short', day:'numeric', month:'short', hour:'2-digit', minute:'2-digit' });
+  const endStr = end.toLocaleString(undefined, { hour:'2-digit', minute:'2-digit' });
+  return `${startStr} → ${endStr}`;
 }

--- a/server/worker.js
+++ b/server/worker.js
@@ -1,48 +1,37 @@
 export default {
   async fetch(request) {
     if (request.method === 'OPTIONS') {
-      return new Response(null, {
-        headers: corsHeaders()
-      });
+      return new Response(null, { headers: cors() });
     }
-
     const url = new URL(request.url);
     if (url.pathname === '/ical') {
       const icsUrl = url.searchParams.get('url');
-      const headers = corsHeaders();
-      if (!icsUrl) {
-        return new Response(JSON.stringify({ error: 'Missing url' }), { status: 400, headers });
-      }
+      const headers = cors();
+      if (!icsUrl) return new Response(JSON.stringify({error:'Missing url'}), { status:400, headers });
       let remote;
-      try {
-        remote = new URL(icsUrl);
-      } catch {
-        return new Response(JSON.stringify({ error: 'Invalid url' }), { status: 400, headers });
-      }
-      const allowed = ['airbnb.com', 'airbnb.com.au', 'vrbo.com'];
-      if (!allowed.some(h => remote.hostname === h || remote.hostname.endsWith('.' + h))) {
-        return new Response(JSON.stringify({ error: 'Host not allowed' }), { status: 400, headers });
+      try { remote = new URL(icsUrl); } catch { return new Response(JSON.stringify({error:'Invalid url'}), { status:400, headers }); }
+      const allowed = ['airbnb.com','airbnb.com.au','abnb.me','vrbo.com','booking.com'];
+      if (!allowed.some(h => remote.hostname === h || remote.hostname.endsWith('.'+h))) {
+        return new Response(JSON.stringify({error:'Host not allowed'}), { status:400, headers });
       }
       try {
         const resp = await fetch(icsUrl);
-        if (!resp.ok) {
-          return new Response(JSON.stringify({ error: 'Upstream error' }), { status: 502, headers });
-        }
+        if (!resp.ok) return new Response(JSON.stringify({error:'Upstream error'}), { status:502, headers });
         const text = await resp.text();
         const events = parseICS(text);
-        return new Response(JSON.stringify({ events }), { headers });
+        return new Response(JSON.stringify({events}), { headers });
       } catch {
-        return new Response(JSON.stringify({ error: 'Fetch failed' }), { status: 500, headers });
+        return new Response(JSON.stringify({error:'Fetch failed'}), { status:500, headers });
       }
     }
-    return new Response('Not found', { status: 404, headers: corsHeaders() });
+    return new Response('Not found', { status:404, headers: cors() });
   }
 };
 
-function corsHeaders() {
+function cors() {
   return {
-    'Content-Type': 'application/json',
-    'Access-Control-Allow-Origin': '*'
+    'Content-Type':'application/json',
+    'Access-Control-Allow-Origin':'*'
   };
 }
 
@@ -52,27 +41,25 @@ function parseICS(text) {
   for (const block of blocks) {
     const body = block.split('END:VEVENT')[0];
     const lines = body.split(/\r?\n/);
-    let start, end, summary;
+    let start,end,summary;
     for (const line of lines) {
       if (line.startsWith('DTSTART')) {
-        const [, v] = line.split(':');
-        start = parseICalDate(v.trim());
+        const [,v] = line.split(':');
+        start = parseDate(v.trim());
       } else if (line.startsWith('DTEND')) {
-        const [, v] = line.split(':');
-        end = parseICalDate(v.trim());
+        const [,v] = line.split(':');
+        end = parseDate(v.trim());
       } else if (line.startsWith('SUMMARY')) {
-        const [, v] = line.split(':');
+        const [,v] = line.split(':');
         summary = v.trim();
       }
     }
-    if (start && end) {
-      events.push({ start, end, summary });
-    }
+    if (start && end) events.push({ start, end, summary });
   }
   return events;
 }
 
-function parseICalDate(str) {
+function parseDate(str) {
   if (/^\d{8}$/.test(str)) {
     return `${str.slice(0,4)}-${str.slice(4,6)}-${str.slice(6,8)}T00:00:00`;
   }

--- a/styles.css
+++ b/styles.css
@@ -5,36 +5,48 @@
   --ok:#1a7f37;
   --err:#d1242f;
 }
+*{box-sizing:border-box;}
 body{
-  font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
   margin:0;
-  padding:0;
+  font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
   color:var(--text);
   background:#fff;
+  line-height:1.5;
 }
-.container{max-width:600px;margin:0 auto;padding:20px;}
-h1{font-size:1.5rem;}
-.hero{background:var(--brand);color:#fff;text-align:center;padding:60px 20px;}
-.hero h1{margin:0;font-size:2rem;}
-.hero p{margin-top:8px;font-size:1.1rem;}
-.intro,.process{margin:40px 0;}
-.process ol{padding-left:20px;}
+.brand{padding:16px;text-align:center;}
+.logo{height:48px;}
+.hero{text-align:center;padding:60px 20px;background:var(--brand);color:#fff;}
+.hero .tagline{margin-top:8px;font-size:1.25rem;}
+.hero .pitch{max-width:600px;margin:16px auto;}
+.actions{display:flex;gap:12px;justify-content:center;margin-top:24px;flex-wrap:wrap;}
+.btn{display:inline-block;background:var(--brand);color:#fff;padding:10px 16px;border-radius:4px;text-decoration:none;border:1px solid var(--brand);}
+.btn.ghost{background:transparent;color:var(--brand);}
+.btn:focus{outline:2px solid currentColor;outline-offset:2px;}
+.container{max-width:700px;margin:0 auto;padding:40px 20px;}
+section{margin:40px 0;}
+.cards{list-style:none;padding:0;margin:24px 0;display:grid;gap:12px;}
+.cards li{background:#f8f9fb;padding:16px;border:1px solid var(--line);border-radius:6px;}
+.note{font-size:.9rem;color:#555;}
+.lead form,.calendar form{display:flex;flex-direction:column;gap:12px;}
+label{font-weight:600;}
+input,textarea{padding:8px;border:1px solid var(--line);border-radius:4px;font:inherit;}
+textarea{resize:vertical;}
+.checkbox{font-weight:400;}
 .row{display:flex;gap:8px;}
-#ical-url{flex:1;padding:8px;border:1px solid var(--line);border-radius:4px;}
-button{padding:8px 12px;border:none;background:var(--brand);color:#fff;border-radius:4px;cursor:pointer;}
-button:disabled{opacity:.6;cursor:not-allowed;}
-ul{list-style:none;padding:0;margin:16px 0;}
-.event{border-bottom:1px solid var(--line);padding:8px 0;}
-.event .top{display:flex;align-items:center;gap:8px;}
-.event .summary{font-weight:600;}
-.event .dates{font-size:.9rem;margin-left:4px;color:var(--text);}
-.event .note{margin-left:24px;margin-top:4px;width:100%;padding:6px;border:1px solid var(--line);border-radius:4px;}
-.status{min-height:1.2em;margin-top:8px;}
-.status.err{color:var(--err);}
+.row input{flex:1;}
+.status{min-height:1.2em;}
 .status.ok{color:var(--ok);}
+.status.err{color:var(--err);}
 .hidden{display:none;}
+#events-list{list-style:none;padding:0;margin:0;}
+#events-list li{border-bottom:1px solid var(--line);padding:8px 0;}
+#events-list label{display:flex;align-items:center;gap:8px;}
+#events-list .dates{font-size:.9rem;color:#555;}
+#events-list .note{margin-top:4px;width:100%;}
+.footnote{font-size:.8rem;color:#555;margin-top:8px;}
+.footer{background:#f8f9fb;text-align:center;padding:20px;font-size:.9rem;border-top:1px solid var(--line);}
 @media (max-width:480px){
   .row{flex-direction:column;}
-  button{width:100%;}
-  .event .note{margin-left:0;}
+  .actions{flex-direction:column;}
+  .btn{width:100%;text-align:center;}
 }


### PR DESCRIPTION
## Summary
- create static marketing page with hero copy, sample request form, and calendar-driven hamper selection
- handle Formspree submissions and iCal loading with vanilla JS
- add Cloudflare Worker to proxy iCal feeds from approved hosts
- remove placeholder Open Graph image file; note in README to add one later

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c73e0e2270832eb895b50ff04940a1